### PR TITLE
Refactor and cleanup of webkit_inspection_protocol.dart

### DIFF
--- a/lib/src/console.dart
+++ b/lib/src/console.dart
@@ -1,0 +1,87 @@
+// Copyright 2015 Google. All rights reserved. Use of this source code is
+// governed by a BSD-style license that can be found in the LICENSE file.
+
+part of wip;
+
+class WipConsole extends WipDomain {
+  final _messageController =
+      new StreamController<ConsoleMessageEvent>.broadcast();
+  final _clearedController = new StreamController.broadcast();
+
+  ConsoleMessageEvent _lastMessage;
+
+  WipConsole(WipConnection connection) : super(connection) {
+    connection._registerDomain('Console', this);
+
+    _register('Console.messageAdded', _messageAdded);
+    _register('Console.messageRepeatCountUpdated', _messageRepeatCountUpdated);
+    _register('Console.messagesCleared', _messagesCleared);
+  }
+
+  Future enable() => _sendCommand('Console.enable');
+  Future disable() => _sendCommand('Console.disable');
+  Future clearMessages() => _sendCommand('Console.clearMessages');
+
+  Stream<ConsoleMessageEvent> get onMessage => _messageController.stream;
+  Stream get onCleared => _clearedController.stream;
+
+  void _messageAdded(WipEvent event) {
+    _lastMessage = new ConsoleMessageEvent(event);
+    _messageController.add(_lastMessage);
+  }
+
+  void _messageRepeatCountUpdated(WipEvent event) {
+    if (_lastMessage != null) {
+      _lastMessage.params['repeatCount'] = event.params['count'];
+      _messageController.add(_lastMessage);
+    }
+  }
+
+  void _messagesCleared(WipEvent event) {
+    _lastMessage = null;
+    _clearedController.add(null);
+  }
+
+  @override
+  void close() {
+    _messageController.close();
+    _clearedController.close();
+  }
+}
+
+/**
+ * See [WipConsole.onMessage].
+ */
+class ConsoleMessageEvent extends _WrappedWipEvent {
+  ConsoleMessageEvent(WipEvent event) : super(event);
+
+  Map get _message => params['message'];
+
+  String get text => _message['text'];
+  String get level => _message['level'];
+  String get url => _message['url'];
+  int get repeatCount => _message['repeatCount'];
+
+  Iterable<WipConsoleCallFrame> getStackTrace() {
+    if (_message.containsKey('stackTrace')) {
+      return params['stackTrace']
+          .map((frame) => new WipConsoleCallFrame.fromMap(frame));
+    } else {
+      return [];
+    }
+  }
+
+  String toString() => text;
+}
+
+class WipConsoleCallFrame {
+  final Map<String, dynamic> _map;
+
+  WipConsoleCallFrame.fromMap(this._map);
+
+  int get columnNumber => _map['columnNumber'];
+  String get functionName => _map['functionName'];
+  int get lineNumber => _map['lineNumber'];
+  String get scriptId => _map['scriptId'];
+  String get url => _map['url'];
+}

--- a/lib/src/debugger.dart
+++ b/lib/src/debugger.dart
@@ -1,0 +1,161 @@
+// Copyright 2015 Google. All rights reserved. Use of this source code is
+// governed by a BSD-style license that can be found in the LICENSE file.
+
+part of wip;
+
+class WipDebugger extends WipDomain {
+  final _pausedController =
+      new StreamController<DebuggerPausedEvent>.broadcast();
+  final _resumedController = new StreamController.broadcast();
+
+  Map<String, WipScript> _scripts = {};
+
+  WipDebugger(WipConnection connection) : super(connection) {
+    connection._registerDomain('Debugger', this);
+
+    // TODO:
+    //_register('Debugger.breakpointResolved', _breakpointResolved);
+    _register('Debugger.globalObjectCleared', _globalObjectCleared);
+    _register('Debugger.paused', _paused);
+    _register('Debugger.resumed', _resumed);
+    //_register('Debugger.scriptFailedToParse', _scriptFailedToParse);
+    _register('Debugger.scriptParsed', _scriptParsed);
+  }
+
+  Future enable() => _sendCommand('Debugger.enable');
+  Future disable() => _sendCommand('Debugger.disable');
+
+  Future<String> getScriptSource(String scriptId) async {
+    var resp =
+        await _sendCommand('Debugger.getScriptSource', {'scriptId': scriptId});
+    return resp.result['scriptSource'];
+  }
+
+  Future pause() => _sendCommand('Debugger.pause');
+  Future resume() => _sendCommand('Debugger.resume');
+
+  Future stepInto() => _sendCommand('Debugger.stepInto');
+  Future stepOut() => _sendCommand('Debugger.stepOut');
+  Future stepOver() => _sendCommand('Debugger.stepOver');
+
+  /**
+   * State should be one of "all", "none", or "uncaught".
+   */
+  Future setPauseOnExceptions(String state) =>
+      _sendCommand('Debugger.setPauseOnExceptions', {'state': state});
+
+  Stream get onPaused => _pausedController.stream;
+  Stream get onResumed => _resumedController.stream;
+
+  WipScript getScript(String scriptId) => _scripts[scriptId];
+
+  void _globalObjectCleared(WipEvent event) {
+    _scripts.clear();
+  }
+
+  void _paused(WipEvent event) {
+    _pausedController.add(new DebuggerPausedEvent(event));
+  }
+
+  void _resumed(WipEvent event) {
+    _resumedController.add(null);
+  }
+
+  void _scriptParsed(WipEvent event) {
+    var script = new WipScript(event.params);
+    _scripts[script.scriptId] = script;
+    print(script);
+  }
+
+  @override
+  void close() {
+    _pausedController.close();
+    _resumedController.close();
+  }
+}
+
+class DebuggerPausedEvent extends _WrappedWipEvent {
+  DebuggerPausedEvent(WipEvent event) : super(event);
+
+  String get reason => params['reason'];
+  Object get data => params['data'];
+
+  Iterable<WipCallFrame> getCallFrames() =>
+      params['callFrames'].map((frame) => new WipCallFrame(frame));
+
+  String toString() => 'paused: ${reason}';
+}
+
+class WipCallFrame {
+  final Map<String, dynamic> _map;
+
+  WipCallFrame(this._map);
+
+  String get callFrameId => _map['callFrameId'];
+  String get functionName => _map['functionName'];
+  WipLocation get location => new WipLocation(_map['location']);
+  WipRemoteObject get thisObject => new WipRemoteObject(_map['this']);
+
+  Iterable<WipScope> getScopeChain() =>
+      _map['scopeChain'].map((scope) => new WipScope(scope));
+
+  String toString() => '[${functionName}]';
+}
+
+class WipLocation {
+  final Map<String, dynamic> _map;
+
+  WipLocation(this._map);
+
+  int get columnNumber => _map['columnNumber'];
+  int get lineNumber => _map['lineNumber'];
+  String get scriptId => _map['scriptId'];
+
+  String toString() => '[${scriptId}:${lineNumber}:${columnNumber}]';
+}
+
+class WipRemoteObject {
+  final Map<String, dynamic> _map;
+
+  WipRemoteObject(this._map);
+
+  String get className => _map['className'];
+  String get description => _map['description'];
+  String get objectId => _map['objectId'];
+  String get subtype => _map['subtype'];
+  String get type => _map['type'];
+  Object get value => _map['value'];
+}
+
+class WipScript {
+  final Map<String, dynamic> _map;
+
+  WipScript(this._map);
+
+  String get scriptId => _map['scriptId'];
+  String get url => _map['url'];
+  int get startLine => _map['startLine'];
+  int get startColumn => _map['startColumn'];
+  int get endLine => _map['endLine'];
+  int get endColumn => _map['endColumn'];
+  bool get isContentScript => _map['isContentScript'];
+  String get sourceMapURL => _map['sourceMapURL'];
+
+  String toString() => '[script ${scriptId}: ${url}]';
+}
+
+class WipScope {
+  final Map<String, dynamic> _map;
+
+  WipScope(this._map);
+
+  // "catch", "closure", "global", "local", "with"
+  String get scope => _map['scope'];
+
+  /**
+   * Object representing the scope. For global and with scopes it represents the
+   * actual object; for the rest of the scopes, it is artificial transient
+   * object enumerating scope variables as its properties.
+   */
+  WipRemoteObject get object => new WipRemoteObject(_map['object']);
+}

--- a/lib/src/dom.dart
+++ b/lib/src/dom.dart
@@ -20,8 +20,8 @@ class WipDom extends WipDomain {
   }
 
   Future<Map<String, String>> getAttributes(int nodeId) async {
-    _Event resp =
-        await _sendCommand(new _Event('DOM.getAttributes', {'nodeId': nodeId}));
+    WipResponse resp =
+        await _sendCommand('DOM.getAttributes', {'nodeId': nodeId});
     var attributes = {};
     for (int i = 0; i < resp.result['attributes'].length; i += 2) {
       attributes[resp.result['attributes'][i]] =
@@ -31,12 +31,12 @@ class WipDom extends WipDomain {
   }
 
   Future<Node> getDocument() async =>
-      new Node((await _sendSimpleCommand('DOM.getDocument')).result['root']);
+      new Node((await _sendCommand('DOM.getDocument')).result['root']);
 
   Future<String> getOuterHtml(int nodeId) async => (await _sendCommand(
-      new _Event('DOM.getOuterHTML', {'nodeId': nodeId}))).result['root'];
+      'DOM.getOuterHTML', {'nodeId': nodeId})).result['root'];
 
-  Future hideHighlight() => _sendSimpleCommand('DOM.hideHighlight');
+  Future hideHighlight() => _sendCommand('DOM.hideHighlight');
 
   Future highlightNode(int nodeId, {Rgba borderColor, Rgba contentColor,
       Rgba marginColor, Rgba paddingColor, bool showInfo}) {
@@ -62,7 +62,7 @@ class WipDom extends WipDomain {
       params['highlightConfig']['showInfo'] = showInfo;
     }
 
-    return _sendCommand(new _Event('DOM.highlightNode', params));
+    return _sendCommand('DOM.highlightNode', params);
   }
 
   Future highlightRect(int x, int y, int width, int height,
@@ -77,7 +77,7 @@ class WipDom extends WipDomain {
       params['outlineColor'] = outlineColor;
     }
 
-    return _sendCommand(new _Event('DOM.highlightRect', params));
+    return _sendCommand('DOM.highlightRect', params);
   }
 
   Future<int> moveTo(int nodeId, int targetNodeId,
@@ -88,31 +88,30 @@ class WipDom extends WipDomain {
       params['insertBeforeNodeId'] = insertBeforeNodeId;
     }
 
-    var resp = await _sendCommand(new _Event('DOM.moveTo', params));
+    var resp = await _sendCommand('DOM.moveTo', params);
     return resp.result['nodeId'];
   }
 
   Future<int> querySelector(int nodeId, String selector) async {
-    var resp = await _sendCommand(new _Event(
-        'DOM.querySelector', {'nodeId': nodeId, 'selector': selector}));
+    var resp = await _sendCommand(
+        'DOM.querySelector', {'nodeId': nodeId, 'selector': selector});
     return resp.result['nodeId'];
   }
 
   Future<List<int>> querySelectorAll(int nodeId, String selector) async {
-    var resp = await _sendCommand(new _Event(
-        'DOM.querySelectorAll', {'nodeId': nodeId, 'selector': selector}));
+    var resp = await _sendCommand(
+        'DOM.querySelectorAll', {'nodeId': nodeId, 'selector': selector});
     return resp.result['nodeIds'];
   }
 
-  Future removeAttribute(int nodeId, String name) => _sendCommand(
-      new _Event('DOM.removeAttribute', {'nodeId': nodeId, 'name': name}));
+  Future removeAttribute(int nodeId, String name) =>
+      _sendCommand('DOM.removeAttribute', {'nodeId': nodeId, 'name': name});
   Future removeNode(int nodeId) =>
-      _sendCommand(new _Event('DOM.removeNode', {'nodeId': nodeId}));
+      _sendCommand('DOM.removeNode', {'nodeId': nodeId});
   Future requestChildNodes(int nodeId) =>
-      _sendCommand(new _Event('DOM.requestChildNodes', {'nodeId': nodeId}));
+      _sendCommand('DOM.requestChildNodes', {'nodeId': nodeId});
   Future<int> requestNode(String objectId) async {
-    var resp = await _sendCommand(
-        new _Event('DOM.requestNode', {'objectId': objectId}));
+    var resp = await _sendCommand('DOM.requestNode', {'objectId': objectId});
     return resp.result['nodeId'];
   }
 
@@ -122,124 +121,138 @@ class WipDom extends WipDomain {
       params['objectGroup'] = objectGroup;
     }
 
-    var resp = await _sendCommand(new _Event('DOM.resolveNode', params));
+    var resp = await _sendCommand('DOM.resolveNode', params);
     return new WipRemoteObject(resp.result['object']);
   }
 
   Future setAttributeValue(int nodeId, String name, String value) =>
-      _sendCommand(new _Event('DOM.setAttributeValue', {
+      _sendCommand('DOM.setAttributeValue', {
     'nodeId': nodeId,
     'name': name,
     'value': value
-  }));
+  });
   Future setAttributesAsText(int nodeId, String text, {String name}) {
     var params = {'nodeId': nodeId, 'text': text};
     if (name != null) {
       params['name'] = name;
     }
-    _sendCommand(new _Event('DOM.setAttributeValue', params));
+    return _sendCommand('DOM.setAttributeValue', params);
   }
 
   Future<int> setNodeName(int nodeId, String name) async {
-    var resp = await _sendCommand(
-        new _Event('DOM.setNodeName', {'nodeId': nodeId, 'name': name}));
+    var resp =
+        await _sendCommand('DOM.setNodeName', {'nodeId': nodeId, 'name': name});
     return resp.result['nodeId'];
   }
 
-  Future setNodeValue(int nodeId, String value) => _sendCommand(
-      new _Event('DOM.setNodeValue', {'nodeId': nodeId, 'value': value}));
+  Future setNodeValue(int nodeId, String value) =>
+      _sendCommand('DOM.setNodeValue', {'nodeId': nodeId, 'value': value});
 
-  Future setOuterHtml(int nodeId, String outerHtml) => _sendCommand(new _Event(
-      'DOM.setOuterHTML', {'nodeId': nodeId, 'outerHtml': outerHtml}));
+  Future setOuterHtml(int nodeId, String outerHtml) => _sendCommand(
+      'DOM.setOuterHTML', {'nodeId': nodeId, 'outerHtml': outerHtml});
 
   final _attributeModifiedController =
       new StreamController<AttributeModifiedEvent>.broadcast();
   Stream<AttributeModifiedEvent> get onAttributeModified =>
       _attributeModifiedController.stream;
-  void _attributeModified(_Event event) =>
+  void _attributeModified(WipEvent event) =>
       _attributeModifiedController.add(new AttributeModifiedEvent(event));
 
   final _attributeRemovedController =
       new StreamController<AttributeRemovedEvent>.broadcast();
   Stream<AttributeRemovedEvent> get onAttributeRemoved =>
       _attributeRemovedController.stream;
-  void _attributeRemoved(_Event event) =>
+  void _attributeRemoved(WipEvent event) =>
       _attributeRemovedController.add(new AttributeRemovedEvent(event));
 
   final _characterDataModifiedController =
       new StreamController<CharacterDataModifiedEvent>.broadcast();
   Stream<CharacterDataModifiedEvent> get onCharacterDataModified =>
       _characterDataModifiedController.stream;
-  void _characterDataModified(_Event event) => _characterDataModifiedController
-      .add(new CharacterDataModifiedEvent(event));
+  void _characterDataModified(WipEvent event) =>
+      _characterDataModifiedController
+          .add(new CharacterDataModifiedEvent(event));
 
   final _childNodeCountUpdatedController =
       new StreamController<ChildNodeCountUpdatedEvent>.broadcast();
   Stream<ChildNodeCountUpdatedEvent> get onChildNodeCountUpdated =>
       _childNodeCountUpdatedController.stream;
-  void _childNodeCountUpdated(_Event event) => _childNodeCountUpdatedController
-      .add(new ChildNodeCountUpdatedEvent(event));
+  void _childNodeCountUpdated(WipEvent event) =>
+      _childNodeCountUpdatedController
+          .add(new ChildNodeCountUpdatedEvent(event));
 
   final _childNodeInsertedController =
       new StreamController<ChildNodeInsertedEvent>.broadcast();
   Stream<ChildNodeInsertedEvent> get onChildNodeInserted =>
       _childNodeInsertedController.stream;
-  void _childNodeInserted(_Event event) =>
+  void _childNodeInserted(WipEvent event) =>
       _childNodeInsertedController.add(new ChildNodeInsertedEvent(event));
 
   final _childNodeRemovedController =
       new StreamController<ChildNodeRemovedEvent>.broadcast();
   Stream<ChildNodeRemovedEvent> get onChildNodeRemoved =>
       _childNodeRemovedController.stream;
-  void _childNodeRemoved(_Event event) =>
+  void _childNodeRemoved(WipEvent event) =>
       _childNodeRemovedController.add(new ChildNodeRemovedEvent(event));
 
   final _documentUpdatedController =
       new StreamController<DocumentUpdatedEvent>.broadcast();
   Stream<DocumentUpdatedEvent> get onDocumentUpdated =>
       _documentUpdatedController.stream;
-  void _documentUpdated(_Event event) =>
+  void _documentUpdated(WipEvent event) =>
       _documentUpdatedController.add(new DocumentUpdatedEvent(event));
 
   final _setChildNodesController =
       new StreamController<SetChildNodesEvent>.broadcast();
   Stream<SetChildNodesEvent> get onSetChildNodes =>
       _setChildNodesController.stream;
-  void _setChildNodes(_Event event) =>
+  void _setChildNodes(WipEvent event) =>
       _setChildNodesController.add(new SetChildNodesEvent(event));
+
+  @override
+  void close() {
+    _attributeModifiedController.close();
+    _attributeRemovedController.close();
+    _characterDataModifiedController.close();
+    _childNodeCountUpdatedController.close();
+    _childNodeInsertedController.close();
+    _childNodeRemovedController.close();
+    _documentUpdatedController.close();
+    _setChildNodesController.close();
+  }
 }
 
-class AttributeModifiedEvent extends WipEvent {
-  AttributeModifiedEvent(_Event event) : super(event.map);
+class AttributeModifiedEvent extends _WrappedWipEvent {
+  AttributeModifiedEvent(WipEvent event) : super(event);
 
   int get nodeId => params['nodeId'];
   String get name => params['name'];
   String get value => params['value'];
 }
 
-class AttributeRemovedEvent extends WipEvent {
-  AttributeRemovedEvent(_Event event) : super(event.map);
+class AttributeRemovedEvent extends _WrappedWipEvent {
+  AttributeRemovedEvent(WipEvent event) : super(event);
 
   int get nodeId => params['nodeId'];
   String get name => params['name'];
 }
 
-class CharacterDataModifiedEvent extends WipEvent {
-  CharacterDataModifiedEvent(_Event event) : super(event.map);
+class CharacterDataModifiedEvent extends _WrappedWipEvent {
+  CharacterDataModifiedEvent(WipEvent event) : super(event);
 
   int get nodeId => params['nodeId'];
   String get characterData => params['characterData'];
 }
 
-class ChildNodeCountUpdatedEvent extends WipEvent {
-  ChildNodeCountUpdatedEvent(_Event event) : super(event.map);
+class ChildNodeCountUpdatedEvent extends _WrappedWipEvent {
+  ChildNodeCountUpdatedEvent(WipEvent event) : super(event);
 
   int get nodeId => params['nodeId'];
   int get childNodeCount => params['childNodeCount'];
 }
 
-class ChildNodeInsertedEvent extends WipEvent {
-  ChildNodeInsertedEvent(_Event event) : super(event.map);
+class ChildNodeInsertedEvent extends _WrappedWipEvent {
+  ChildNodeInsertedEvent(WipEvent event) : super(event);
 
   int get parentNodeId => params['parentNodeId'];
   int get previousNodeId => params['previousNodeId'];
@@ -252,19 +265,19 @@ class ChildNodeInsertedEvent extends WipEvent {
   }
 }
 
-class ChildNodeRemovedEvent extends WipEvent {
-  ChildNodeRemovedEvent(_Event event) : super(event.map);
+class ChildNodeRemovedEvent extends _WrappedWipEvent {
+  ChildNodeRemovedEvent(WipEvent event) : super(event);
 
   int get parentNodeId => params['parentNodeId'];
   int get nodeId => params['nodeId'];
 }
 
-class DocumentUpdatedEvent extends WipEvent {
-  DocumentUpdatedEvent(_Event event) : super(event.map);
+class DocumentUpdatedEvent extends _WrappedWipEvent {
+  DocumentUpdatedEvent(WipEvent event) : super(event);
 }
 
-class SetChildNodesEvent extends WipEvent {
-  SetChildNodesEvent(_Event event) : super(event.map);
+class SetChildNodesEvent extends _WrappedWipEvent {
+  SetChildNodesEvent(WipEvent event) : super(event);
 
   int get nodeId => params['parentId'];
   Iterable<Node> get nodes sync* {
@@ -277,61 +290,64 @@ class SetChildNodesEvent extends WipEvent {
 /// The backend keeps track of which DOM nodes have been sent,
 /// will only send each node once, and will only send events
 /// for nodes that have been sent.
-class Node extends WipObject {
-  Node(Map<String, dynamic> map) : super(map);
+class Node {
+  final Map<String, dynamic> _map;
+
+  Node(this._map);
 
   var _attributes;
   Map<String, String> get attributes {
-    if (_attributes == null && map.containsKey('attributes')) {
+    if (_attributes == null && _map.containsKey('attributes')) {
       var attributes = {};
-      for (int i = 0; i < map['attributes'].length; i += 2) {
-        attributes[map['attributes'][i]] = attributes[map['attributes'][i + 1]];
+      for (int i = 0; i < _map['attributes'].length; i += 2) {
+        attributes[_map['attributes'][i]] =
+            attributes[_map['attributes'][i + 1]];
       }
       _attributes = new UnmodifiableMapView<String, String>(attributes);
     }
     return _attributes;
   }
 
-  int get childNodeCount => map['childNodeCount'];
+  int get childNodeCount => _map['childNodeCount'];
 
   Iterable<Node> get children sync* {
-    if (map.containsKey('children')) {
-      for (var child in map['children']) {
+    if (_map.containsKey('children')) {
+      for (var child in _map['children']) {
         yield new Node(child);
       }
     }
   }
 
   Node get contentDocument {
-    if (map.containsKey('contentDocument')) {
-      return new Node(map['contentDocument']);
+    if (_map.containsKey('contentDocument')) {
+      return new Node(_map['contentDocument']);
     }
     return null;
   }
 
-  String get documentUrl => map['documentURL'];
+  String get documentUrl => _map['documentURL'];
 
-  String get internalSubset => map['internalSubset'];
+  String get internalSubset => _map['internalSubset'];
 
-  String get localName => map['localName'];
+  String get localName => _map['localName'];
 
-  String get name => map['name'];
+  String get name => _map['name'];
 
-  int get nodeId => map['nodeId'];
+  int get nodeId => _map['nodeId'];
 
-  String get nodeName => map['nodeName'];
+  String get nodeName => _map['nodeName'];
 
-  int get nodeType => map['nodeType'];
+  int get nodeType => _map['nodeType'];
 
-  String get nodeValue => map['nodeValue'];
+  String get nodeValue => _map['nodeValue'];
 
-  String get publicId => map['publicId'];
+  String get publicId => _map['publicId'];
 
-  String get systemId => map['systemId'];
+  String get systemId => _map['systemId'];
 
-  String get value => map['value'];
+  String get value => _map['value'];
 
-  String get xmlVersion => map['xmlVersion'];
+  String get xmlVersion => _map['xmlVersion'];
 }
 
 class Rgba {

--- a/lib/src/page.dart
+++ b/lib/src/page.dart
@@ -1,0 +1,36 @@
+// Copyright 2015 Google. All rights reserved. Use of this source code is
+// governed by a BSD-style license that can be found in the LICENSE file.
+
+part of wip;
+
+class WipPage extends WipDomain {
+  WipPage(WipConnection connection) : super(connection) {
+    connection._registerDomain('Page', this);
+
+    // TODO:
+    // Page.loadEventFired
+    // Page.domContentEventFired
+  }
+
+  Future enable() => _sendCommand('Page.enable');
+  Future disable() => _sendCommand('Page.disable');
+
+  Future navigate(String url) => _sendCommand('Page.navigate', {'url': url});
+
+  Future reload({bool ignoreCache, String scriptToEvaluateOnLoad}) {
+    var params = {};
+
+    if (ignoreCache != null) {
+      params['ignoreCache'] = ignoreCache;
+    }
+
+    if (scriptToEvaluateOnLoad != null) {
+      params['scriptToEvaluateOnLoad'] = scriptToEvaluateOnLoad;
+    }
+
+    return _sendCommand('Page.navigate', params);
+  }
+
+  @override
+  void close() {}
+}

--- a/lib/webkit_inspection_protocol.dart
+++ b/lib/webkit_inspection_protocol.dart
@@ -6,12 +6,17 @@
  */
 library wip;
 
-import 'dart:async';
-import 'dart:collection';
+import 'dart:async' show Completer, Future, Stream, StreamController;
+import 'dart:collection' show UnmodifiableMapView;
 import 'dart:convert' show JSON, UTF8;
-import 'dart:io';
+import 'dart:io' show HttpClient, HttpClientResponse, WebSocket;
 
+import 'package:logging/logging.dart' show Logger;
+
+part 'src/console.dart';
+part 'src/debugger.dart';
 part 'src/dom.dart';
+part 'src/page.dart';
 
 /**
  * A class to connect to a Chrome instance and reflect on its available tabs.
@@ -20,58 +25,60 @@ part 'src/dom.dart';
  * flag. The data is read from the `http://{host}:{port}/json` url.
  */
 class ChromeConnection {
-  String _url;
+  final HttpClient _client = new HttpClient();
 
-  ChromeConnection(String host, [int port = 9222]) {
-    _url = 'http://${host}:${port}/json';
+  final Uri url;
+
+  ChromeConnection(String host, [int port = 9222])
+      : url = Uri.parse('http://${host}:${port}/');
+
+  // TODO(DrMarcII): consider changing this to return Stream<ChromeTab>.
+  Future<List<ChromeTab>> getTabs() async {
+    var response = await getUrl('/json');
+    var respBody = await UTF8.decodeStream(response);
+    List<Map<String, String>> data = JSON.decode(respBody);
+    return data.map((m) => new ChromeTab(m));
   }
 
-  String get url => _url;
-
-  Future<List<ChromeTab>> getTabs() {
-    return _httpGet(url).then((String str) {
-      List list = JSON.decode(str);
-      return list.map((m) => new ChromeTab.fromMap(m));
-    });
-  }
-
-  Future<ChromeTab> getTab(bool accept(ChromeTab tab), {Duration retryFor}) {
-    DateTime start = new DateTime.now();
-
-    // TODO: could switch to a repeated stream of events and a completer
-
-    var _retry = () => false;
+  Future<ChromeTab> getTab(bool accept(ChromeTab tab),
+      {Duration retryFor}) async {
+    var start = new DateTime.now();
+    var end = start;
     if (retryFor != null) {
-      _retry = () => new DateTime.now().difference(start) < retryFor;
+      end = start.add(retryFor);
     }
 
-    var _getTab;
-    _getTab = () {
-      return getTabs().then((tabs) {
-        tabs = tabs.where(accept);
-        if (!tabs.isEmpty) return tabs.first;
-        if (_retry()) {
-          return new Future.delayed(
-              new Duration(milliseconds: 25)).then((_) => _getTab());
+    while (true) {
+      try {
+        for (var tab in await getTabs()) {
+          if (accept(tab)) {
+            return tab;
+          }
         }
-        return null;
-      }).catchError((e) {
-        if (_retry()) {
-          return new Future.delayed(
-              new Duration(milliseconds: 25)).then((_) => _getTab());
+        if (end.isBefore(new DateTime.now())) {
+          return null;
         }
-        throw e;
-      });
-    };
-
-    return _getTab();
+      } catch (e) {
+        if (end.isBefore(new DateTime.now())) {
+          rethrow;
+        }
+      }
+      await new Future.delayed(new Duration(milliseconds: 25));
+    }
   }
+
+  Future<HttpClientResponse> getUrl(String path) async {
+    var request = await _client.getUrl(url.resolve(path));
+    return await request.close();
+  }
+
+  void close() => _client.close(force: true);
 }
 
 class ChromeTab {
   final Map _map;
 
-  ChromeTab.fromMap(this._map);
+  ChromeTab(this._map);
 
   String get description => _map['description'];
   String get devtoolsFrontendUrl => _map['devtoolsFrontendUrl'];
@@ -101,6 +108,8 @@ class ChromeTab {
  * A Webkit Inspection Protocol (WIP) connection.
  */
 class WipConnection {
+  static final _log = new Logger('WipConnection');
+
   /**
    * The WebSocket URL.
    */
@@ -110,17 +119,21 @@ class WipConnection {
 
   int _nextId = 0;
 
-  WipConsole console;
-  WipDebugger debugger;
-  WipPage page;
-  WipRuntime runtime;
-  WipDom dom;
+  var _console;
+  WipConsole get console => _console;
+  var _debugger;
+  WipDebugger get debugger => _debugger;
+  var _dom;
+  WipDom get dom => _dom;
+  var _page;
+  WipPage get page => _page;
 
-  Map _domains = {};
+  final _domains = <String, WipDomain>{};
 
-  Map<int, Completer> _completers = {};
+  final _completers = <int, Completer<WipResponse>>{};
 
-  StreamController<WipConnection> _closeController = new StreamController.broadcast();
+  final _closeController = new StreamController<WipConnection>.broadcast();
+  final _notificationController = new StreamController<WipEvent>.broadcast();
 
   static Future<WipConnection> connect(String url) {
     return WebSocket.connect(url).then((socket) {
@@ -129,24 +142,24 @@ class WipConnection {
   }
 
   WipConnection._(this.url, this._ws) {
-    console = new WipConsole(this);
-    debugger = new WipDebugger(this);
-    page = new WipPage(this);
-    runtime = new WipRuntime(this);
-    dom = new WipDom(this);
+    _console = new WipConsole(this);
+    _debugger = new WipDebugger(this);
+    _dom = new WipDom(this);
+    _page = new WipPage(this);
 
     _ws.listen((data) {
-      _Event event = new _Event._fromMap(JSON.decode(data));
+      var json = JSON.decode(data);
 
-      if (event.isNotification) {
-        _handleNotification(event);
+      if (json.containsKey('id')) {
+        _handleResponse(json);
       } else {
-        _handleResponse(event);
+        _handleNotification(json);
       }
     }, onDone: _handleClose);
   }
 
   Stream<WipConnection> get onClose => _closeController.stream;
+  Stream<WipEvent> get onNotification => _notificationController.stream;
 
   Future close() => _ws.close();
 
@@ -156,418 +169,116 @@ class WipConnection {
     _domains[domainId] = domain;
   }
 
-  Future<_Event> _sendCommand(_Event event) {
-    Completer completer = new Completer();
-    event.id = _nextId++;
-    _completers[event.id] = completer;
-    _ws.add(event.toJson());
+  Future<WipResponse> sendCommand(String method,
+      [Map<String, dynamic> params]) {
+    var completer = new Completer<WipResponse>();
+    var json = {'id': _nextId++, 'method': method};
+    if (params != null) {
+      json['params'] = params;
+    }
+    _completers[json['id']] = completer;
+    _ws.add(JSON.encode(json));
     return completer.future;
   }
 
-  void _handleNotification(_Event event) {
-    String domainId = event.method;
-    int index = domainId.indexOf('.');
+  void _handleNotification(Map<String, dynamic> json) {
+    var event = new WipEvent(json);
+    var domainId = event.method;
+    var index = domainId.indexOf('.');
     if (index != -1) {
       domainId = domainId.substring(0, index);
     }
     if (_domains.containsKey(domainId)) {
       _domains[domainId]._handleNotification(event);
     } else {
-      _log('unhandled event notification: ${event.method}');
+      _log.warning('unhandled event notification: ${event.method}');
     }
+    _notificationController.add(event);
   }
 
-  void _handleResponse(_Event event) {
-    Completer completer = _completers.remove(event.id);
+  void _handleResponse(Map<String, dynamic> event) {
+    var completer = _completers.remove(event['id']);
 
-    assert(completer != null);
-
-    if (event.hasError) {
+    if (event.containsKey('error')) {
       completer.completeError(new WipError(event));
     } else {
       completer.complete(new WipResponse(event));
     }
   }
 
-  void _log(String str) {
-    print(str);
-  }
-
   void _handleClose() {
     _closeController.add(this);
+    _closeController.close();
+    _notificationController.close();
+    _domains.values.forEach((d) => d.close());
   }
 }
 
-abstract class WipObject {
-  final Map map;
+class WipEvent {
+  final String method;
+  final Map<String, dynamic> params;
 
-  WipObject(this.map);
-}
+  WipEvent(Map<String, dynamic> map)
+      : method = map['method'],
+        params = map['params'];
 
-class WipEvent extends WipObject {
-  WipEvent(Map map) : super(map);
-
-  String get method => map['method'];
-  Map get params => map['params'];
-
-  String toString() => '${method}()';
+  String toString() => 'WipEvent: $method($params)';
 }
 
 class WipError {
   final int id;
   final dynamic error;
 
-  WipError(_Event event) : id = event.id, error = event.error;
+  WipError(Map<String, dynamic> json)
+      : id = json['id'],
+        error = json['error'];
 
-  String toString() => '${error}';
+  String toString() => 'WipError $id: $error';
 }
 
 class WipResponse {
   final int id;
-  final Map result;
+  final Map<String, dynamic> result;
 
-  WipResponse(_Event event) : id = event.id, result = event.result;
+  WipResponse(Map<String, dynamic> json)
+      : id = json['id'],
+        result = json['result'];
 
-  String toString() => '${result}';
+  String toString() => 'WipResponse $id: $result';
 }
 
-abstract class WipDomain {
-  Map<String, Function> _callbacks = {};
+typedef WipEventCallback(WipEvent event);
 
-  WipConnection connection;
+abstract class WipDomain {
+  Map<String, WipEventCallback> _callbacks = {};
+
+  final WipConnection connection;
 
   WipDomain(this.connection);
 
-  void _register(String method, Function callback) {
+  void _register(String method, WipEventCallback callback) {
     _callbacks[method] = callback;
   }
 
-  void _handleNotification(_Event event) {
-    Function f = _callbacks[event.method];
+  void _handleNotification(WipEvent event) {
+    var f = _callbacks[event.method];
     if (f != null) f(event);
   }
 
-  Future<_Event> _sendSimpleCommand(String method) {
-    return connection._sendCommand(new _Event(method));
-  }
+  Future<WipResponse> _sendCommand(String method,
+      [Map<String, dynamic> params]) => connection.sendCommand(method, params);
 
-  Future<_Event> _sendCommand(_Event event) => connection._sendCommand(event);
+  void close();
 }
 
-class WipConsole extends WipDomain {
-  StreamController<ConsoleMessageEvent> _message = new StreamController.broadcast();
-  StreamController _cleared = new StreamController.broadcast();
+class _WrappedWipEvent implements WipEvent {
+  final WipEvent _wrapped;
 
-  ConsoleMessageEvent _lastMessage;
+  _WrappedWipEvent(this._wrapped);
 
-  WipConsole(WipConnection connection): super(connection) {
-    connection._registerDomain('Console', this);
+  @override
+  String get method => _wrapped.method;
 
-    _register('Console.messageAdded', _messageAdded);
-    _register('Console.messageRepeatCountUpdated', _messageRepeatCountUpdated);
-    _register('Console.messagesCleared', _messagesCleared);
-  }
-
-  Future enable() => _sendSimpleCommand('Console.enable');
-  Future disable() => _sendSimpleCommand('Console.disable');
-  Future clearMessages() => _sendSimpleCommand('Console.clearMessages');
-
-  Stream<ConsoleMessageEvent> get onMessage => _message.stream;
-  Stream get onCleared => _cleared.stream;
-
-  void _messageAdded(_Event event) {
-    _lastMessage = new ConsoleMessageEvent(event);
-    _message.add(_lastMessage);
-  }
-
-  void _messageRepeatCountUpdated(_Event event) {
-    if (_lastMessage != null) {
-      _lastMessage.params['repeatCount'] = event.params['count'];
-      _message.add(_lastMessage);
-    }
-  }
-
-  void _messagesCleared(_Event event) {
-    _lastMessage = null;
-    _cleared.add(null);
-  }
-}
-
-class WipDebugger extends WipDomain {
-  StreamController _pausedController = new StreamController.broadcast();
-  StreamController _resumedController = new StreamController.broadcast();
-
-  Map<String, WipScript> _scripts = {};
-
-  WipDebugger(WipConnection connection): super(connection) {
-    connection._registerDomain('Debugger', this);
-
-    // TODO:
-    //_register('Debugger.breakpointResolved', _breakpointResolved);
-    _register('Debugger.globalObjectCleared', _globalObjectCleared);
-    _register('Debugger.paused', _paused);
-    _register('Debugger.resumed', _resumed);
-    //_register('Debugger.scriptFailedToParse', _scriptFailedToParse);
-    _register('Debugger.scriptParsed', _scriptParsed);
-  }
-
-  Future enable() => _sendSimpleCommand('Debugger.enable');
-  Future disable() => _sendSimpleCommand('Debugger.disable');
-
-  Future<String> getScriptSource(String scriptId) {
-    return _sendCommand(new _Event(
-        'Debugger.getScriptSource', {'scriptId': scriptId})).then((_Event event) {
-      return event.result['scriptSource'];
-    });
-  }
-
-  Future pause() => _sendSimpleCommand('Debugger.pause');
-  Future resume() => _sendSimpleCommand('Debugger.resume');
-
-  Future stepInto() => _sendSimpleCommand('Debugger.stepInto');
-  Future stepOut() => _sendSimpleCommand('Debugger.stepOut');
-  Future stepOver() => _sendSimpleCommand('Debugger.stepOver');
-
-  /**
-   * State should be one of "all", "none", or "uncaught".
-   */
-  Future setPauseOnExceptions(String state) {
-    var event = new _Event('Debugger.setPauseOnExceptions', {'state': state});
-    return connection._sendCommand(event);
-  }
-
-  Stream get onPaused => _pausedController.stream;
-  Stream get onResumed => _resumedController.stream;
-
-  WipScript getScript(String scriptId) => _scripts[scriptId];
-
-  void _globalObjectCleared(_Event event) {
-    _scripts.clear();
-  }
-
-  void _paused(_Event event) {
-    _pausedController.add(new DebuggerPausedEvent(event));
-  }
-
-  void _resumed(_Event event) {
-    _resumedController.add(null);
-  }
-
-  void _scriptParsed(_Event event) {
-    WipScript script = new WipScript(event.params);
-    _scripts[script.scriptId] = script;
-    print(script);
-  }
-}
-
-class WipPage extends WipDomain {
-  WipPage(WipConnection connection): super(connection) {
-    connection._registerDomain('Page', this);
-
-    // TODO:
-    // Page.loadEventFired
-    // Page.domContentEventFired
-  }
-
-  Future enable() => _sendSimpleCommand('Page.enable');
-  Future disable() => _sendSimpleCommand('Page.disable');
-
-  Future navigate(String url) {
-    return connection._sendCommand(new _Event('Page.navigate', {'url': url}));
-  }
-
-  Future reload({bool ignoreCache, String scriptToEvaluateOnLoad}) {
-    _Event event = new _Event('Page.navigate');
-
-    if (ignoreCache != null) {
-      event.addParam('ignoreCache', ignoreCache);
-    }
-
-    if (scriptToEvaluateOnLoad != null) {
-      event.addParam('scriptToEvaluateOnLoad', scriptToEvaluateOnLoad);
-    }
-
-    return connection._sendCommand(event);
-  }
-}
-
-class WipRuntime extends WipDomain {
-  WipRuntime(WipConnection connection): super(connection) {
-    connection._registerDomain('Page', this);
-  }
-}
-
-/**
- * See [WipConsole.onMessage].
- */
-class ConsoleMessageEvent extends WipEvent {
-  ConsoleMessageEvent(_Event event): super(event.map);
-
-  Map get _message => params['message'];
-
-  String get text => _message['text'];
-  String get level => _message['level'];
-  String get url => _message['url'];
-  int get repeatCount => _message['repeatCount'];
-
-  Iterable<WipCallFrame> getStackTrace() {
-    if (_message.containsKey('stackTrace')) {
-      return params['stackTrace'].map((frame) => new WipConsoleCallFrame(frame));
-    } else {
-      return [];
-    }
-  }
-
-  String toString() => text;
-}
-
-class WipConsoleCallFrame extends WipObject {
-  WipConsoleCallFrame(Map m): super(m);
-
-  int get columnNumber => map['columnNumber'];
-  String get functionName => map['functionName'];
-  int get lineNumber => map['lineNumber'];
-  String get scriptId => map['scriptId'];
-  String get url => map['url'];
-}
-
-class DebuggerPausedEvent extends WipEvent {
-  DebuggerPausedEvent(_Event event): super(event.map);
-
-  String get reason => params['reason'];
-  Object get data => params['data'];
-
-  Iterable<WipCallFrame> getCallFrames() {
-    return params['callFrames'].map((frame) => new WipCallFrame(frame));
-  }
-
-  String toString() => 'paused: ${reason}';
-}
-
-class ScriptParsedEvent extends WipEvent {
-  ScriptParsedEvent(Map params): super(params);
-
-  String get scriptId => params['scriptId'];
-  String get url => params['url'];
-  int get startLine => params['startLine'];
-  int get startColumn => params['startColumn'];
-  int get endLine => params['endLine'];
-  int get endColumn => params['endColumn'];
-  bool get isContentScript => params['isContentScript'];
-  String get sourceMapURL => params['sourceMapURL'];
-}
-
-class WipCallFrame extends WipObject {
-  WipCallFrame(Map params): super(params);
-
-  String get callFrameId => map['callFrameId'];
-  String get functionName => map['functionName'];
-  WipLocation get location => new WipLocation(map['location']);
-  WipRemoteObject get thisObject => new WipRemoteObject(map['this']);
-
-  Iterable<WipScope> getScopeChain() {
-    return map['scopeChain'].map((scope) => new WipScope(scope));
-  }
-
-  String toString() => '[${functionName}]';
-}
-
-class WipLocation extends WipObject {
-  WipLocation(Map params): super(params);
-
-  int get columnNumber => map['columnNumber'];
-  int get lineNumber => map['lineNumber'];
-  String get scriptId => map['scriptId'];
-
-  String toString() => '[${scriptId}:${lineNumber}:${columnNumber}]';
-}
-
-class WipScript extends WipObject {
-  WipScript(Map m): super(m);
-
-  String get scriptId => map['scriptId'];
-  String get url => map['url'];
-  int get startLine => map['startLine'];
-  int get startColumn => map['startColumn'];
-  int get endLine => map['endLine'];
-  int get endColumn => map['endColumn'];
-  bool get isContentScript => map['isContentScript'];
-  String get sourceMapURL => map['sourceMapURL'];
-
-  String toString() => '[script ${scriptId}: ${url}]';
-}
-
-class WipScope extends WipObject {
-  WipScope(Map params): super(params);
-
-  // "catch", "closure", "global", "local", "with"
-  String get scope => map['scope'];
-
-  /**
-   * Object representing the scope. For global and with scopes it represents the
-   * actual object; for the rest of the scopes, it is artificial transient
-   * object enumerating scope variables as its properties.
-   */
-  WipRemoteObject get object => new WipRemoteObject(map['object']);
-}
-
-class WipRemoteObject extends WipObject {
-  WipRemoteObject(Map map): super(map);
-
-  String get className => map['className'];
-  String get description => map['description'];
-  String get objectId => map['objectId'];
-  String get subtype => map['subtype'];
-  String get type => map['type'];
-  Object get value => map['value'];
-}
-
-class _Event {
-  final Map map;
-
-  _Event(String method, [Map params]) : map = {} {
-    map['method'] = method;
-
-    if (params != null) {
-      map['params'] = params;
-    }
-  }
-
-  _Event._fromMap(this.map);
-
-  String get method => map['method'];
-
-  int get id => map['id'];
-
-  set id(int value) {
-    map['id'] = value;
-  }
-
-  bool get isNotification => !map.containsKey('id');
-
-  bool get hasError => map.containsKey('error');
-  Object get error => map['error'];
-
-  Map get result => map['result'];
-
-  Map get params => map['params'];
-
-  void addParam(String key, Object value) {
-    map[key] = value;
-  }
-
-  String toJson() => JSON.encode(map);
-
-  String toString() => isNotification ? '${method}()' : '${method}() [${id}]';
-}
-
-Future<String> _httpGet(String url) {
-  HttpClient client = new HttpClient();
-  return client.getUrl(Uri.parse(url)).then((HttpClientRequest request) {
-    return request.close();
-  }).then((HttpClientResponse response) {
-    return response.toList();
-  }).then((List<List> data) {
-    return UTF8.decode(data.reduce((a, b) => a.addAll(b)));
-  });
+  @override
+  Map<String, dynamic> get params => _wrapped.params;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,3 +7,5 @@ author: Devon Carew <devoncarew@google.com>
 
 environment:
   sdk: '>=1.9.0 <2.0.0'
+dependencies:
+  logging: '^0.11.1'


### PR DESCRIPTION
 - Move each domain into a separate part.
 - Delete some unused/unfinished code.
 - Simplify code by removing _Event and WipObject classes.
 - Change some code to use async/await.
 - Add generic public onNotification stream and sendCommand method to WipConnection to support planned debug port multiplexor.