### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webkit_inspection_protocol
-version: 0.0.1+1
+version: 0.1.0
 description: A client for the Webkit Inspection Protocol (WIP).
 
 homepage: https://github.com/google/webkit_inspection_protocol.dart


### PR DESCRIPTION
Bump the pubspec version for the next time we release, to avoid compatibility issues with clients using `^0.0.1` as a version constraint.

@DrMarcII 