### PR TITLE
Change forwarder to not send paused events unless a breakpoint event has been sent.

### DIFF
--- a/bin/multiplex.dart
+++ b/bin/multiplex.dart
@@ -15,7 +15,7 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
 main(List<String> argv) async {
   var args = (new ArgParser()
     ..addFlag('verbose', abbr: 'v', defaultsTo: false, negatable: false)
-    ..addFlag('model_dom', defaultsTo: true, negatable: true)
+    ..addFlag('model_dom', defaultsTo: false, negatable: true)
     ..addOption('chrome_host', defaultsTo: 'localhost')
     ..addOption('chrome_port', defaultsTo: '9222')
     ..addOption('listen_port', defaultsTo: '9223')).parse(argv);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webkit_inspection_protocol
-version: 0.1.1+1
+version: 0.1.2
 description: A client for the Webkit Inspection Protocol (WIP).
 
 homepage: https://github.com/google/webkit_inspection_protocol.dart
@@ -8,10 +8,10 @@ author: Devon Carew <devoncarew@google.com>
 environment:
   sdk: '>=1.10.0 <2.0.0'
 dependencies:
-  args: '^0.13.0'
-  logging: '^0.11.0'
-  shelf: '^0.6.1+2'
+  args: '^0.13.2'
+  logging: '^0.11.1'
+  shelf: '^0.6.2'
   shelf_web_socket: '^0.0.1+2'
 dev_dependencies:
   shelf_static: '^0.2.2'
-  test: '^0.12.3+2'
+  test: '^0.12.3+5'


### PR DESCRIPTION
This is useful when using the multiplexor to debug a web app while running a webdriver test against it, as chromedriver will automatically resume if a paused event is received.

Change bin/multiplex model_dom option to false by default.