### PR TITLE
Uses inspector.html instead of devtools.html

### DIFF
--- a/lib/multiplex.dart
+++ b/lib/multiplex.dart
@@ -74,7 +74,7 @@ class Server {
 
     for (var tab in await chrome.getTabs()) {
       html
-        ..write('<tr><td><a href="/devtools/devtools.html?ws=localhost:')
+        ..write('<tr><td><a href="/devtools/inspector.html?ws=localhost:')
         ..write(port)
         ..write('/devtools/page/')
         ..write(tab.id)
@@ -156,8 +156,8 @@ class Server {
     if (obj is ChromeTab) {
       var json = <String, dynamic>{
         'description': obj.description,
-        'devtoolsFrontendUrl':
-            '/devtools/devtools.html?ws=localhost:$port/devtools/page/${obj.id}',
+        'devtoolsFrontendUrl': '/devtools/inspector.html'
+            '?ws=localhost:$port/devtools/page/${obj.id}',
         'id': obj.id,
         'title': obj.title,
         'type': obj.type,


### PR DESCRIPTION
Chrome 45 uses /devtools/inspector.html instead of /devtools/devtools.html.

e.g. localhost:9222/json

{
   "description": "",
   "devtoolsFrontendUrl": "/devtools/inspector.html?ws=localhost:9222/devtools/page/57DD6140-1AE2-482A-87F2-6656522AB965",
   "faviconUrl": "https://www.google.com/favicon.ico",
   "id": "57DD6140-1AE2-482A-87F2-6656522AB965",
   "title": "New Tab",
   "type": "page",
   "url": "http://localhost:9222/json",
   "webSocketDebuggerUrl": "ws://localhost:9222/devtools/page/57DD6140-1AE2-482A-87F2-6656522AB965"
}