### PR TITLE
expose log and runtime domain; deprecate console

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # webkit_inspection_protocol.dart
 
+## 0.3.0
+- Expose the `runtime` domain.
+- Expose the `log` domain.
+- Deprecated the `console` domain.
+- Fix a bug in `Page.reload()`.
+- Remove the use of parts.
+
 ## 0.2.2
 - Make the package strong mode clean.
 

--- a/lib/src/console.dart
+++ b/lib/src/console.dart
@@ -1,27 +1,27 @@
 // Copyright 2015 Google. All rights reserved. Use of this source code is
 // governed by a BSD-style license that can be found in the LICENSE file.
 
-part of wip;
+import 'dart:async';
 
+import '../webkit_inspection_protocol.dart';
+
+@Deprecated('This domain is deprecated - use Runtime or Log instead')
 class WipConsole extends WipDomain {
   WipConsole(WipConnection connection) : super(connection);
 
-  Future enable() => _sendCommand('Console.enable');
-  Future disable() => _sendCommand('Console.disable');
-  Future clearMessages() => _sendCommand('Console.clearMessages');
+  Future enable() => sendCommand('Console.enable');
+  Future disable() => sendCommand('Console.disable');
+  Future clearMessages() => sendCommand('Console.clearMessages');
 
-  Stream<ConsoleMessageEvent> get onMessage => _eventStream(
+  Stream<ConsoleMessageEvent> get onMessage => eventStream(
       'Console.messageAdded',
       (WipEvent event) => new ConsoleMessageEvent(event));
-  Stream<ConsoleClearedEvent> get onCleared => _eventStream(
+  Stream<ConsoleClearedEvent> get onCleared => eventStream(
       'Console.messagesCleared',
       (WipEvent event) => new ConsoleClearedEvent(event));
 }
 
-/**
- * See [WipConsole.onMessage].
- */
-class ConsoleMessageEvent extends _WrappedWipEvent {
+class ConsoleMessageEvent extends WrappedWipEvent {
   ConsoleMessageEvent(WipEvent event) : super(event);
 
   Map get _message => params['message'];
@@ -42,7 +42,7 @@ class ConsoleMessageEvent extends _WrappedWipEvent {
   String toString() => text;
 }
 
-class ConsoleClearedEvent extends _WrappedWipEvent {
+class ConsoleClearedEvent extends WrappedWipEvent {
   ConsoleClearedEvent(WipEvent event) : super(event);
 }
 

--- a/lib/src/debugger.dart
+++ b/lib/src/debugger.dart
@@ -1,7 +1,10 @@
 // Copyright 2015 Google. All rights reserved. Use of this source code is
 // governed by a BSD-style license that can be found in the LICENSE file.
 
-part of wip;
+import 'dart:async';
+import 'dart:collection';
+
+import '../webkit_inspection_protocol.dart';
 
 class WipDebugger extends WipDomain {
   final _scripts = <String, WipScript>{};
@@ -15,31 +18,33 @@ class WipDebugger extends WipDomain {
     });
   }
 
-  Future enable() => _sendCommand('Debugger.enable');
-  Future disable() => _sendCommand('Debugger.disable');
+  Future enable() => sendCommand('Debugger.enable');
+  Future disable() => sendCommand('Debugger.disable');
 
   Future<String> getScriptSource(String scriptId) async =>
-      (await _sendCommand('Debugger.getScriptSource', {'scriptId': scriptId}))
+      (await sendCommand('Debugger.getScriptSource',
+              params: {'scriptId': scriptId}))
           .result['scriptSource'];
 
-  Future pause() => _sendCommand('Debugger.pause');
-  Future resume() => _sendCommand('Debugger.resume');
+  Future pause() => sendCommand('Debugger.pause');
+  Future resume() => sendCommand('Debugger.resume');
 
-  Future stepInto() => _sendCommand('Debugger.stepInto');
-  Future stepOut() => _sendCommand('Debugger.stepOut');
-  Future stepOver() => _sendCommand('Debugger.stepOver');
+  Future stepInto() => sendCommand('Debugger.stepInto');
+  Future stepOut() => sendCommand('Debugger.stepOut');
+  Future stepOver() => sendCommand('Debugger.stepOver');
 
-  Future setPauseOnExceptions(PauseState state) => _sendCommand(
-      'Debugger.setPauseOnExceptions', {'state': _pauseStateToString(state)});
+  Future setPauseOnExceptions(PauseState state) =>
+      sendCommand('Debugger.setPauseOnExceptions',
+          params: {'state': _pauseStateToString(state)});
 
-  Stream<DebuggerPausedEvent> get onPaused => _eventStream(
+  Stream<DebuggerPausedEvent> get onPaused => eventStream(
       'Debugger.paused', (WipEvent event) => new DebuggerPausedEvent(event));
-  Stream<GlobalObjectClearedEvent> get onGlobalObjectCleared => _eventStream(
+  Stream<GlobalObjectClearedEvent> get onGlobalObjectCleared => eventStream(
       'Debugger.globalObjectCleared',
       (WipEvent event) => new GlobalObjectClearedEvent(event));
-  Stream<DebuggerResumedEvent> get onResumed => _eventStream(
+  Stream<DebuggerResumedEvent> get onResumed => eventStream(
       'Debugger.resumed', (WipEvent event) => new DebuggerResumedEvent(event));
-  Stream<ScriptParsedEvent> get onScriptParsed => _eventStream(
+  Stream<ScriptParsedEvent> get onScriptParsed => eventStream(
       'Debugger.scriptParsed',
       (WipEvent event) => new ScriptParsedEvent(event));
 
@@ -61,7 +66,7 @@ String _pauseStateToString(PauseState state) {
 
 enum PauseState { all, none, uncaught }
 
-class ScriptParsedEvent extends _WrappedWipEvent {
+class ScriptParsedEvent extends WrappedWipEvent {
   final WipScript script;
 
   ScriptParsedEvent(WipEvent event)
@@ -69,15 +74,15 @@ class ScriptParsedEvent extends _WrappedWipEvent {
         super(event);
 }
 
-class GlobalObjectClearedEvent extends _WrappedWipEvent {
+class GlobalObjectClearedEvent extends WrappedWipEvent {
   GlobalObjectClearedEvent(WipEvent event) : super(event);
 }
 
-class DebuggerResumedEvent extends _WrappedWipEvent {
+class DebuggerResumedEvent extends WrappedWipEvent {
   DebuggerResumedEvent(WipEvent event) : super(event);
 }
 
-class DebuggerPausedEvent extends _WrappedWipEvent {
+class DebuggerPausedEvent extends WrappedWipEvent {
   DebuggerPausedEvent(WipEvent event) : super(event);
 
   String get reason => params['reason'];

--- a/lib/src/log.dart
+++ b/lib/src/log.dart
@@ -1,0 +1,39 @@
+// Copyright 2017 Google. All rights reserved. Use of this source code is
+// governed by a BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import '../webkit_inspection_protocol.dart';
+
+class WipLog extends WipDomain {
+  WipLog(WipConnection connection) : super(connection);
+
+  Future enable() => sendCommand('Log.enable');
+  Future disable() => sendCommand('Log.disable');
+
+  Stream<LogEntry> get onEntryAdded =>
+      eventStream('Log.entryAdded', (WipEvent event) => new LogEntry(event));
+}
+
+class LogEntry extends WrappedWipEvent {
+  LogEntry(WipEvent event) : super(event);
+
+  Map<String, dynamic> get _entry => params['entry'];
+
+  /// Log entry source. Allowed values: xml, javascript, network, storage,
+  /// appcache, rendering, security, deprecation, worker, violation,
+  /// intervention, other.
+  String get source => _entry['source'];
+
+  /// Log entry severity. Allowed values: verbose, info, warning, error.
+  String get level => _entry['level'];
+
+  /// Logged text.
+  String get text => _entry['text'];
+
+  /// URL of the resource if known.
+  @optional
+  String get url => _entry['url'];
+
+  String toString() => text;
+}

--- a/lib/src/page.dart
+++ b/lib/src/page.dart
@@ -1,15 +1,18 @@
 // Copyright 2015 Google. All rights reserved. Use of this source code is
 // governed by a BSD-style license that can be found in the LICENSE file.
 
-part of wip;
+import 'dart:async';
+
+import '../webkit_inspection_protocol.dart';
 
 class WipPage extends WipDomain {
   WipPage(WipConnection connection) : super(connection);
 
-  Future enable() => _sendCommand('Page.enable');
-  Future disable() => _sendCommand('Page.disable');
+  Future enable() => sendCommand('Page.enable');
+  Future disable() => sendCommand('Page.disable');
 
-  Future navigate(String url) => _sendCommand('Page.navigate', {'url': url});
+  Future navigate(String url) =>
+      sendCommand('Page.navigate', params: {'url': url});
 
   Future reload({bool ignoreCache, String scriptToEvaluateOnLoad}) {
     var params = {};
@@ -22,6 +25,6 @@ class WipPage extends WipDomain {
       params['scriptToEvaluateOnLoad'] = scriptToEvaluateOnLoad;
     }
 
-    return _sendCommand('Page.navigate', params);
+    return sendCommand('Page.reload', params: params);
   }
 }

--- a/lib/src/runtime.dart
+++ b/lib/src/runtime.dart
@@ -1,0 +1,153 @@
+// Copyright 2015 Google. All rights reserved. Use of this source code is
+// governed by a BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math';
+
+import '../webkit_inspection_protocol.dart';
+
+class WipRuntime extends WipDomain {
+  WipRuntime(WipConnection connection) : super(connection);
+
+  Future enable() => sendCommand('Runtime.enable');
+  Future disable() => sendCommand('Runtime.disable');
+
+  Stream<ConsoleAPIEvent> get onConsoleAPICalled => eventStream(
+      'Runtime.consoleAPICalled',
+      (WipEvent event) => new ConsoleAPIEvent(event));
+
+  Stream<ExceptionThrownEvent> get onExceptionThrown => eventStream(
+      'Runtime.exceptionThrown',
+      (WipEvent event) => new ExceptionThrownEvent(event));
+}
+
+class ConsoleAPIEvent extends WrappedWipEvent {
+  ConsoleAPIEvent(WipEvent event) : super(event);
+
+  /// Type of the call. Allowed values: log, debug, info, error, warning, dir,
+  /// dirxml, table, trace, clear, startGroup, startGroupCollapsed, endGroup,
+  /// assert, profile, profileEnd.
+  String get type => params['type'];
+
+  /// Call arguments.
+  List<RemoteObject> get args =>
+      (params['args'] as List).map((m) => new RemoteObject(m)).toList();
+
+  // TODO: stackTrace, StackTrace, Stack trace captured when the call was made.
+}
+
+class ExceptionThrownEvent extends WrappedWipEvent {
+  ExceptionThrownEvent(WipEvent event) : super(event);
+
+  /// Timestamp of the exception.
+  int get timestamp => params['timestamp'];
+
+  ExceptionDetails get exceptionDetails =>
+      new ExceptionDetails(params['exceptionDetails']);
+}
+
+class ExceptionDetails {
+  final Map<String, dynamic> _map;
+
+  ExceptionDetails(this._map);
+
+  /// Exception id.
+  int get exceptionId => _map['exceptionId'];
+
+  /// Exception text, which should be used together with exception object when
+  /// available.
+  String get text => _map['text'];
+
+  /// Line number of the exception location (0-based).
+  int get lineNumber => _map['lineNumber'];
+
+  /// Column number of the exception location (0-based).
+  int get columnNumber => _map['columnNumber'];
+
+  /// URL of the exception location, to be used when the script was not
+  /// reported.
+  @optional
+  String get url => _map['url'];
+
+  /// Script ID of the exception location.
+  @optional
+  String get scriptId => _map['scriptId'];
+
+  /// JavaScript stack trace if available.
+  @optional
+  StackTrace get stackTrace =>
+      _map['stackTrace'] == null ? null : new StackTrace(_map['stackTrace']);
+
+  /// Exception object if available.
+  @optional
+  RemoteObject get exception =>
+      _map['exception'] == null ? null : new RemoteObject(_map['exception']);
+
+  String toString() => text;
+}
+
+class StackTrace {
+  final Map<String, dynamic> _map;
+
+  StackTrace(this._map);
+
+  /// String label of this stack trace. For async traces this may be a name of
+  /// the function that initiated the async call.
+  @optional
+  String get description => _map['description'];
+
+  List<CallFrame> get callFrames =>
+      (_map['callFrames'] as List).map((m) => new CallFrame(m)).toList();
+
+  // TODO: parent, StackTrace, Asynchronous JavaScript stack trace that preceded
+  // this stack, if available.
+
+  List<String> printFrames() {
+    List<CallFrame> frames = callFrames;
+
+    int width = frames.fold(0, (int val, CallFrame frame) {
+      return max(val, frame.functionName.length);
+    });
+
+    return frames.map((CallFrame frame) {
+      return '${frame.functionName}()'.padRight(width + 2) +
+          ' ${frame.url} ${frame.lineNumber}:${frame.columnNumber}';
+    }).toList();
+  }
+
+  String toString() => callFrames.map((f) => '  $f').join('\n');
+}
+
+class CallFrame {
+  final Map<String, dynamic> _map;
+
+  CallFrame(this._map);
+
+  /// JavaScript function name.
+  String get functionName => _map['functionName'];
+
+  /// JavaScript script id.
+  String get scriptId => _map['scriptId'];
+
+  /// JavaScript script name or url.
+  String get url => _map['url'];
+
+  /// JavaScript script line number (0-based).
+  int get lineNumber => _map['lineNumber'];
+
+  /// JavaScript script column number (0-based).
+  int get columnNumber => _map['columnNumber'];
+
+  String toString() => '$functionName() ($url $lineNumber:$columnNumber)';
+}
+
+class RemoteObject {
+  final Map<String, dynamic> _map;
+
+  RemoteObject(this._map);
+
+  String get type => _map['type'];
+  String get value => _map['value'];
+
+  String toString() => '$type $value';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webkit_inspection_protocol
-version: 0.2.2
+version: 0.3.0
 description: A client for the Webkit Inspection Protocol (WIP).
 
 homepage: https://github.com/google/webkit_inspection_protocol.dart

--- a/test/console_test.dart
+++ b/test/console_test.dart
@@ -13,7 +13,7 @@ import 'test_setup.dart';
 
 main() {
   group('WipConsole', () {
-    WipConsole console;
+    WipConsole console; // ignore: deprecated_member_use
     List<ConsoleMessageEvent> events = [];
     var subs = [];
 
@@ -32,6 +32,7 @@ main() {
     }
 
     setUp(() async {
+      // ignore: deprecated_member_use
       console = (await wipConnection).console;
       await console.clearMessages();
       events.clear();


### PR DESCRIPTION
- Expose the `runtime` domain.
- Expose the `log` domain.
- Deprecated the `console` domain.
- Fix a bug in `Page.reload()`.
- Remove the use of parts.

rev to `0.3.0`
