### PR TITLE
Fix uses_dynamic_as_bottom error

### DIFF
--- a/lib/forwarder.dart
+++ b/lib/forwarder.dart
@@ -18,7 +18,7 @@ import 'webkit_inspection_protocol.dart'
 class WipForwarder {
   static final _log = new Logger('ChromeForwarder');
 
-  final Stream _in;
+  final Stream<String> _in;
   final StreamSink _out;
   final WipConnection _debugger;
   final WipDom domModel;


### PR DESCRIPTION
`dartanalyzer lib/` shows one uses_dynamic_as_bottom error. This fixes that.