### PR TITLE
change the RemoteObject.value return type to Object

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,3 @@
 analyzer:
+  errors:
+    deprecated_member_use_from_same_package: ignore

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # webkit_inspection_protocol.dart
 
+## 0.4.0
+- Change the `RemoteObject.value` return type to `Object`.
+
 ## 0.3.6
 - Expose the `target` domain and additional `runtime` domain calls
 

--- a/lib/src/runtime.dart
+++ b/lib/src/runtime.dart
@@ -207,7 +207,7 @@ class RemoteObject {
 
   /// Remote object value in case of primitive values or JSON values (if it was
   /// requested). (optional)
-  String get value => _map['value'];
+  Object get value => _map['value'];
 
   /// String representation of the object. (optional)
   String get description => _map['description'];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webkit_inspection_protocol
-version: 0.3.6
+version: 0.4.0
 description: A client for the Webkit Inspection Protocol (WIP).
 
 homepage: https://github.com/google/webkit_inspection_protocol.dart


### PR DESCRIPTION
Fixes https://github.com/google/webkit_inspection_protocol.dart/issues/41

I did this as a breaking change since it technically is breaking... an explicit cast may now be required.

cc @devoncarew 