### PR TITLE
Fix for HttpClientResponse SDK breaking change

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # webkit_inspection_protocol.dart
 
+## 0.4.2
+- Cast `HttpClientResponse` to `Stream<List<int>>` in response to
+  SDK breaking change.
+
 ## 0.4.1
 - Fix `page.reload` method.
 - Disable implicit casts when developing this package.

--- a/lib/webkit_inspection_protocol.dart
+++ b/lib/webkit_inspection_protocol.dart
@@ -43,7 +43,7 @@ class ChromeConnection {
   // TODO(DrMarcII): consider changing this to return Stream<ChromeTab>.
   Future<List<ChromeTab>> getTabs() async {
     var response = await getUrl('/json');
-    var respBody = await utf8.decodeStream(response);
+    var respBody = await utf8.decodeStream(response.cast<List<int>>());
     return new List<ChromeTab>.from(
         (jsonDecode(respBody) as List).map((m) => new ChromeTab(m as Map)));
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webkit_inspection_protocol
-version: 0.4.1
+version: 0.4.2
 description: A client for the Webkit Inspection Protocol (WIP).
 
 homepage: https://github.com/google/webkit_inspection_protocol.dart


### PR DESCRIPTION
A recent change to HttpClientResponse updated it to
implement `Stream<Uint8List>` rather than `Stream<List<int>>`.
This forwards-compatible change correspondingly casts
the stream to `List<int>`.

https://github.com/dart-lang/sdk/issues/36900