### PR TITLE
Use correct field when reading WipScope

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # webkit_inspection_protocol.dart
 
+## 0.5.0+1
+- fixed a bug in reading type of `WipScope`
+
 ## 0.5.0
 - removed the bin/multiplex.dart binary to the example/ directory
 - remove dependencies on `package:args`, package:shelf`, and `package:shelf_web_socket`

--- a/lib/src/debugger.dart
+++ b/lib/src/debugger.dart
@@ -160,7 +160,7 @@ class WipScope {
   WipScope(this._map);
 
   // "catch", "closure", "global", "local", "with"
-  String get scope => _map['scope'] as String;
+  String get scope => _map['type'] as String;
 
   /// Object representing the scope. For global and with scopes it represents
   /// the actual object; for the rest of the scopes, it is artificial transient

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webkit_inspection_protocol
-version: 0.5.0
+version: 0.5.0+1
 description: A client for the Chrome DevTools Protocol (previously called the Webkit Inspection Protocol).
 
 homepage: https://github.com/google/webkit_inspection_protocol.dart


### PR DESCRIPTION
Use `type` field to get the type of `WipScope` instead of `scope`, which is not set in the remote object returned by chrome.

This closes #49 