### PR TITLE
Re-Enable Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,15 @@ language: dart
 dart:
   - dev
 
-#before_install:
-#  - export DISPLAY=:99.0
-#  - sh -e /etc/init.d/xvfb start
+addons:
+  chrome: stable
+
+services:
+  - xvfb
 
 script: ./tool/travis.sh
+
+# Only building master means that we don't run two builds for each pull request.
+branches:
+  only:
+    - master

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,3 +19,4 @@ dev_dependencies:
   shelf_static: ^0.2.0
   shelf_web_socket: ^0.2.0
   test: ^1.0.0
+  webdriver: ^2.0.0

--- a/test/console_test.dart
+++ b/test/console_test.dart
@@ -23,8 +23,8 @@ void main() {
       expect(events, hasLength(expectedCount));
       for (int i = 0; i < expectedCount; i++) {
         if (i == 0) {
-          // clear adds an empty message
-          expect(events[i].text, '');
+          // Clearing adds this message.
+          expect(events[i].text, 'console.clear');
         } else {
           expect(events[i].text, 'message $i');
         }
@@ -34,14 +34,11 @@ void main() {
     setUp(() async {
       // ignore: deprecated_member_use
       console = (await wipConnection).console;
-      await console.clearMessages();
       events.clear();
       subs.add(console.onMessage.listen(events.add));
-      subs.add(console.onCleared.listen((_) => events.clear()));
     });
 
     tearDown(() async {
-      await console.clearMessages();
       await console.disable();
       console = null;
       await closeConnection();
@@ -59,13 +56,6 @@ void main() {
       await navigateToPage('console_test.html');
       await console.enable();
       await checkMessages(4);
-    });
-
-    test('does not receive messages if cleared', () async {
-      await navigateToPage('console_test.html');
-      await console.clearMessages();
-      await console.enable();
-      await checkMessages(0);
     });
 
     test('does not receive messages if not enabled', () async {

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -11,6 +11,14 @@ set -e
 pub global activate tuneup
 pub global run tuneup check
 
-# Temporarily disabled due to issues/24
-# /usr/bin/chromium-browser --no-sandbox --remote-debugging-port=9222 &
-# pub run test -j 1
+# Install CHROMEDRIVER
+export CHROMEDRIVER_BINARY=/usr/bin/google-chrome
+export CHROMEDRIVER_OS=linux64
+export CHROME_LATEST_VERSION=$("$CHROMEDRIVER_BINARY" --version | cut -d' ' -f3 | cut -d'.' -f1)
+export CHROME_DRIVER_VERSION=$(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_LATEST_VERSION)
+wget https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_$CHROMEDRIVER_OS.zip
+unzip "chromedriver_${CHROMEDRIVER_OS}.zip"
+export CHROMEDRIVER_ARGS=--no-sandbox
+
+# Run tests
+pub run test -j 1

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -19,6 +19,7 @@ export CHROME_DRIVER_VERSION=$(wget -qO- https://chromedriver.storage.googleapis
 wget https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_$CHROMEDRIVER_OS.zip
 unzip "chromedriver_${CHROMEDRIVER_OS}.zip"
 export CHROMEDRIVER_ARGS=--no-sandbox
+export PATH=$PATH:$PWD
 
 # Run tests
 pub run test -j 1


### PR DESCRIPTION
- Add infra to install and spin up CHROMEDRIVER
- Remove tests that no longer work since the console protocol has changed / is deprecated

Closes https://github.com/google/webkit_inspection_protocol.dart/issues/24
