### PR TITLE
Expose name on WipScope

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # webkit_inspection_protocol.dart
 
+## 0.5.3
+- expose name in `WipScope`
+
 ## 0.5.2
 - have `ExceptionDetails` and `WipError` implement `Exception`
 - add `code` and `message` getters to `WipError`

--- a/lib/src/debugger.dart
+++ b/lib/src/debugger.dart
@@ -303,6 +303,9 @@ class WipScope {
   // "catch", "closure", "global", "local", "with"
   String get scope => _map['type'] as String;
 
+  /// Name of the scope, null if unnamed closure or global scope
+  String get name => _map['name'] as String;
+
   /// Object representing the scope. For global and with scopes it represents
   /// the actual object; for the rest of the scopes, it is artificial transient
   /// object enumerating scope variables as its properties.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webkit_inspection_protocol
-version: 0.5.2
+version: 0.5.3
 description: A client for the Chrome DevTools Protocol (previously called the Webkit Inspection Protocol).
 homepage: https://github.com/google/webkit_inspection_protocol.dart
 


### PR DESCRIPTION
Solving the issue https://github.com/dart-lang/sdk/issues/40774 requires that scope name is exposed on WipScope API, so add a field to do so.