### PR TITLE
add APIs to view WIP traffic

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,12 @@
 # webkit_inspection_protocol.dart
 
+## 0.6.0
+- Add `onSend` and `onReceive` in `WipConnection` 
+- Expose `onExecutionContextCreated`, `onExecutionContextDestroyed`,
+  and `onExecutionContextsCleared` on WipRuntime
+
 ## 0.5.3
-- expose name in `WipScope`
+- expose `name` in `WipScope`
 
 ## 0.5.2
 - have `ExceptionDetails` and `WipError` implement `Exception`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webkit_inspection_protocol
-version: 0.5.3
+version: 0.6.0
 description: A client for the Chrome DevTools Protocol (previously called the Webkit Inspection Protocol).
 homepage: https://github.com/google/webkit_inspection_protocol.dart
 


### PR DESCRIPTION
- Add `onSend` and `onReceive` in `WipConnection` 
- Expose `onExecutionContextCreated`, `onExecutionContextDestroyed`,
  and `onExecutionContextsCleared` on WipRuntime
- rev to `0.6.0` in prep for publishing
