### PR TITLE
expose more fields related to async frames

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,12 @@
 # webkit_inspection_protocol.dart
 
+## 0.7.1
+- Exposed `Debugger.setAsyncCallStackDepth`
+- Exposed `StackTrace.parent`
+
 ## 0.7.0
-- Normalized all objects to expose a `json` field for raw access to the protocol information.
-- Exposed Runtime.getProperties, Runtime.getHeapUsage, and Runtime.getIsolateId
+- Normalized all objects to expose a `json` field for raw access to the protocol information
+- Exposed `Runtime.getProperties`, `Runtime.getHeapUsage`, and `Runtime.getIsolateId`
 - Exposed `DebuggerPausedEvent.hitBreakpoints` and `DebuggerPausedEvent.asyncStackTrace`
 - Exposed `WipCallFrame.returnValue`
 - Removed `WrappedWipEvent` (in favor of just using `WipEvent`)

--- a/lib/src/debugger.dart
+++ b/lib/src/debugger.dart
@@ -143,6 +143,16 @@ class WipDebugger extends WipDomain {
     }
   }
 
+  /// Enables or disables async call stacks tracking.
+  ///
+  /// maxDepth - Maximum depth of async call stacks. Setting to 0 will
+  /// effectively disable collecting async call stacks (default).
+  Future<WipResponse> setAsyncCallStackDepth(int maxDepth) {
+    return sendCommand('Debugger.setAsyncCallStackDepth', params: {
+      'maxDepth': maxDepth,
+    });
+  }
+
   Stream<DebuggerPausedEvent> get onPaused => eventStream('Debugger.paused',
       (WipEvent event) => new DebuggerPausedEvent(event.json));
 
@@ -224,6 +234,9 @@ class DebuggerPausedEvent extends WipEvent {
   String toString() => 'paused: ${reason}';
 }
 
+/// A debugger call frame.
+///
+/// This class is for the 'debugger' domain.
 class WipCallFrame {
   final Map<String, dynamic> json;
 

--- a/lib/src/runtime.dart
+++ b/lib/src/runtime.dart
@@ -266,17 +266,21 @@ class StackTrace {
 
   StackTrace(this.json);
 
+  List<CallFrame> get callFrames => (json['callFrames'] as List)
+      .map((m) => new CallFrame(m as Map<String, dynamic>))
+      .toList();
+
   /// String label of this stack trace. For async traces this may be a name of
   /// the function that initiated the async call.
   @optional
   String get description => json['description'] as String;
 
-  List<CallFrame> get callFrames => (json['callFrames'] as List)
-      .map((m) => new CallFrame(m as Map<String, dynamic>))
-      .toList();
-
-  // TODO: parent, StackTrace, Asynchronous JavaScript stack trace that preceded
-  // this stack, if available.
+  /// Asynchronous JavaScript stack trace that preceded this stack, if
+  /// available.
+  @optional
+  StackTrace get parent {
+    return json['callFrames'] == null ? null : StackTrace(json['callFrames']);
+  }
 
   List<String> printFrames() {
     List<CallFrame> frames = callFrames;
@@ -295,6 +299,8 @@ class StackTrace {
 }
 
 /// Stack entry for runtime errors and assertions.
+///
+/// This class is for the 'runtime' domain.
 class CallFrame {
   final Map<String, dynamic> json;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webkit_inspection_protocol
-version: 0.7.0
+version: 0.7.1
 description: A client for the Chrome DevTools Protocol (previously called the Webkit Inspection Protocol).
 homepage: https://github.com/google/webkit_inspection_protocol.dart
 


### PR DESCRIPTION
expose more fields related to async frames:
- Exposed `Debugger.setAsyncCallStackDepth`
- Exposed `StackTrace.parent`
- rev to `0.7.1` in prep for publishing
