### PR TITLE
Fix type issue with GlobalObjectClearedEvents

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -13,3 +13,4 @@ linter:
     - prefer_const_declarations
     - prefer_const_literals_to_create_immutables
     - prefer_final_fields
+    - type_annotate_public_apis

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # webkit_inspection_protocol.dart
 
+## 0.7.3
+- Fix a type issue with `GlobalObjectClearedEvent`s 
+
 ## 0.7.2
 - Fix a bug in `StackTrace.parent`
 

--- a/lib/src/debugger.dart
+++ b/lib/src/debugger.dart
@@ -158,7 +158,7 @@ class WipDebugger extends WipDomain {
 
   Stream<GlobalObjectClearedEvent> get onGlobalObjectCleared => eventStream(
       'Debugger.globalObjectCleared',
-      (WipEvent event) => new GlobalObjectClearedEvent(event));
+      (WipEvent event) => new GlobalObjectClearedEvent(event.json));
 
   Stream<DebuggerResumedEvent> get onResumed => eventStream('Debugger.resumed',
       (WipEvent event) => new DebuggerResumedEvent(event.json));
@@ -194,7 +194,7 @@ class ScriptParsedEvent extends WipEvent {
 }
 
 class GlobalObjectClearedEvent extends WipEvent {
-  GlobalObjectClearedEvent(json) : super(json);
+  GlobalObjectClearedEvent(Map<String, dynamic> json) : super(json);
 }
 
 class DebuggerResumedEvent extends WipEvent {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webkit_inspection_protocol
-version: 0.7.2
+version: 0.7.3
 description: A client for the Chrome DevTools Protocol (previously called the Webkit Inspection Protocol).
 homepage: https://github.com/google/webkit_inspection_protocol.dart
 


### PR DESCRIPTION
This is technically a breaking change but given that the old behavior is invalid we want consumers to catch this error. The somewhat related lint did not catch this specific issue but is good to have anyway.