### PR TITLE
introduce an optional 'onError' parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+
+- Introduce an optional `onError` parameter when setting up an [WipConnection].
+  This can be used to report errors from the underlying [WebSocket].
+
 ## 1.1.0
 
 - Have `ChromeConnection.getTabs` return better exceptions where there's a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.2.0
 
-- Introduce an optional `onError` parameter when setting up an [WipConnection].
+- Introduce an optional `onError` parameter when setting up a [WipConnection].
   This can be used to report errors from the underlying [WebSocket].
 
 ## 1.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webkit_inspection_protocol
-version: 1.1.0
+version: 1.2.0
 description: >
   A client for the Chrome DevTools Protocol (previously called the Webkit
   Inspection Protocol).
@@ -13,7 +13,7 @@ dependencies:
 
 dev_dependencies:
   args: ^2.0.0
-  lints: ^2.0.0
+  lints: '>=1.0.0 <3.0.0'
   shelf_static: ^1.0.0
   shelf_web_socket: ^1.0.0
   shelf: ^1.0.0


### PR DESCRIPTION
- introduce an optional `onError` parameter when setting up a WipConnection
- potentially adddress https://github.com/google/webkit_inspection_protocol.dart/issues/86
